### PR TITLE
message is not mandatory for some HTTP errors.

### DIFF
--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -51,11 +51,11 @@ module LinkedIn
             data = Mash.from_json(response.body)
             raise LinkedIn::Errors::AccessDeniedError.new(data), "(#{data.status}): #{data.message}"
           when 404
-            raise LinkedIn::Errors::NotFoundError, "(#{response.status}): #{response.message}"
+            raise LinkedIn::Errors::NotFoundError, "(#{response.status}): #{response&.message}"
           when 500
-            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.status}): #{response.message}"
+            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.status}): #{response&.message}"
           when 502..503
-            raise LinkedIn::Errors::UnavailableError, "(#{response.status}): #{response.message}"
+            raise LinkedIn::Errors::UnavailableError, "(#{response.status}): #{response&.message}"
           end
         end
 


### PR DESCRIPTION
Quick fix. It only happens when linkedin serves error 500. 

![nomethoderror undefined method message for oauth2 response 0x00005611ed6f3678 2018-01-17 19-21-35](https://user-images.githubusercontent.com/14675/35059505-a58b2a18-fbbb-11e7-8b68-b83d3ee21a39.png)
