### PR TITLE
Santi/fix method missing on exception

### DIFF
--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -51,11 +51,11 @@ module LinkedIn
             data = Mash.from_json(response.body)
             raise LinkedIn::Errors::AccessDeniedError.new(data), "(#{data.status}): #{data.message}"
           when 404
-            raise LinkedIn::Errors::NotFoundError, "(#{response.status}): #{response.message}"
+            raise LinkedIn::Errors::NotFoundError, "(#{response.status}): #{response&.message}"
           when 500
-            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.status}): #{response.message}"
+            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.status}): #{response&.message}"
           when 502..503
-            raise LinkedIn::Errors::UnavailableError, "(#{response.status}): #{response.message}"
+            raise LinkedIn::Errors::UnavailableError, "(#{response.status}): #{response&.message}"
           end
         end
 

--- a/lib/linked_in/helpers/request.rb
+++ b/lib/linked_in/helpers/request.rb
@@ -51,11 +51,12 @@ module LinkedIn
             data = Mash.from_json(response.body)
             raise LinkedIn::Errors::AccessDeniedError.new(data), "(#{data.status}): #{data.message}"
           when 404
-            raise LinkedIn::Errors::NotFoundError, "(#{response.status}): #{response&.message}"
+            raise LinkedIn::Errors::NotFoundError, "(#{response.status}): #{response.message}"
           when 500
-            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{response.status}): #{response&.message}"
+            data = Mash.from_json(response.body)
+            raise LinkedIn::Errors::InformLinkedInError, "LinkedIn had an internal error. Please let them know in the forum. (#{data.status}): #{data.message}"
           when 502..503
-            raise LinkedIn::Errors::UnavailableError, "(#{response.status}): #{response&.message}"
+            raise LinkedIn::Errors::UnavailableError, "(#{response.status}): #{response.message}"
           end
         end
 


### PR DESCRIPTION
Linkedin is sending message attribute in the body. It needs to be handled like the other cases where it takes data from the body as json.

Tested and worked. However, the problem is in linkedIn. It has an internal API error anyway.

 
![nomethoderror undefined method message for oauth2 response 0x00005611ed703488 2018-01-18 10-14-07](https://user-images.githubusercontent.com/14675/35089836-55d080d6-fc38-11e7-8f6c-4adeffa5c575.png)


![callback 2018-01-18 10-14-57](https://user-images.githubusercontent.com/14675/35089882-73c3f5be-fc38-11e7-8f7f-b6cb62ad4ab1.png)
